### PR TITLE
Fix HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,8 +1,12 @@
 <!DOCTYPE html>
 <html>
-	<link rel="stylesheet" href="tienda.css"></link>
-	<script src="jquery-2.2.2.js"></script>
-	<script src="tienda.js"></script>
+	<head>
+		<title>Tienda UV</title>
+		<link rel="stylesheet" href="tienda.css">
+		<script src="jquery-2.2.2.js"></script>
+		<script src="tienda.js"></script>
+		<meta charset="utf-8">
+	</head>
 	<body>
 		<h1>Tienda<b>UV</b></h1>
 		<nav>
@@ -21,40 +25,40 @@
 		</nav>
 		<div id="articulos">
 			<article id="articulo1" data-id="1">
-				<img height="130px" width="120px" src="https://placeholdit.imgix.net/~text?txtsize=14&txt=producto1&w=120&h=130"/>
+				<img height="130" width="120" src="https://placeholdit.imgix.net/~text?txtsize=14&txt=producto1&w=120&h=130" alt="Producto 1">
 				<div class="nombre">Producto 1</div>
 				<div class="precio" >2.2</div>
-				<div class="cantidad"><input type="number" value="1" size="4"><a href="#">Añadir</button></a>
+				<div class="cantidad"><input type="number" value="1" size="4"><a href="#">Añadir</a></div>
 			</article>
 			<article id="articulo2" data-id="2">
-				<img height="130px" width="120px" src="https://placeholdit.imgix.net/~text?txtsize=14&txt=producto2&w=120&h=130"/>
+				<img height="130" width="120" src="https://placeholdit.imgix.net/~text?txtsize=14&txt=producto2&w=120&h=130" alt="Producto 2">
 				<div class="nombre">Producto 2</div>
 				<div class="precio" >1.2</div>
-				<div class="cantidad"><input type="number" value="1" size="4"><a href="#">Añadir</button></a>
+				<div class="cantidad"><input type="number" value="1" size="4"><a href="#">Añadir</a></div>
 			</article>
 			<article id="articulo3" data-id="3">
-				<img height="130px" width="120px" src="https://placeholdit.imgix.net/~text?txtsize=14&txt=producto3&w=120&h=130"/>
+				<img height="130" width="120" src="https://placeholdit.imgix.net/~text?txtsize=14&txt=producto3&w=120&h=130" alt="Producto 3">
 				<div class="nombre">Producto 3</div>
 				<div class="precio" >3.4</div>
-				<div class="cantidad"><input type="number" value="1" size="4"><a href="#">Añadir</button></a>
+				<div class="cantidad"><input type="number" value="1" size="4"><a href="#">Añadir</a></div>
 			</article>
 			<article id="articulo4" data-id="4">
-				<img height="130px" width="120px" src="https://placeholdit.imgix.net/~text?txtsize=14&txt=producto4&w=120&h=130"/>
+				<img height="130" width="120" src="https://placeholdit.imgix.net/~text?txtsize=14&txt=producto4&w=120&h=130" alt="Producto 4">
 				<div class="nombre">Producto 4</div>
 				<div class="precio" >1</div>
-				<div class="cantidad"><input type="number" value="1" size="4"><a href="#">Añadir</button></a>
+				<div class="cantidad"><input type="number" value="1" size="4"><a href="#">Añadir</a></div>
 			</article>
 			<article id="articulo5" data-id="5">
-				<img height="130px" width="120px" src="https://placeholdit.imgix.net/~text?txtsize=14&txt=producto5&w=120&h=130"/>
+				<img height="130" width="120" src="https://placeholdit.imgix.net/~text?txtsize=14&txt=producto5&w=120&h=130" alt="Producto 5">
 				<div class="nombre">Producto 5</div>
 				<div class="precio" >0.89</div>
-				<div class="cantidad"><input type="number" value="1" size="4"><a href="#">Añadir</button></a>
+				<div class="cantidad"><input type="number" value="1" size="4"><a href="#">Añadir</a></div>
 			</article>
 			<article id="articulo6">
-				<img height="130px" width="120px" src="https://placeholdit.imgix.net/~text?txtsize=14&txt=producto6&w=120&h=130"/>
+				<img height="130" width="120" src="https://placeholdit.imgix.net/~text?txtsize=14&txt=producto6&w=120&h=130"  alt="Producto 6">
 				<div class="nombre">Producto 6</div>
 				<div class="precio" >2.22</div>
-				<div class="cantidad"><input type="number" value="1" size="4"><a href="#">Añadir</button></a>
+				<div class="cantidad"><input type="number" value="1" size="4"><a href="#">Añadir</a></div>
 			</article>
 		</div>
 	</body>

--- a/index.html
+++ b/index.html
@@ -25,37 +25,37 @@
 		</nav>
 		<div id="articulos">
 			<article id="articulo1" data-id="1">
-				<img height="130" width="120" src="https://placeholdit.imgix.net/~text?txtsize=14&txt=producto1&w=120&h=130" alt="Producto 1">
+				<img height="130" width="120" src="https://placeholdit.imgix.net/~text?txtsize=14&amp;txt=producto1&amp;w=120&amp;h=130" alt="Producto 1">
 				<div class="nombre">Producto 1</div>
 				<div class="precio" >2.2</div>
 				<div class="cantidad"><input type="number" value="1" size="4"><a href="#">Añadir</a></div>
 			</article>
 			<article id="articulo2" data-id="2">
-				<img height="130" width="120" src="https://placeholdit.imgix.net/~text?txtsize=14&txt=producto2&w=120&h=130" alt="Producto 2">
+				<img height="130" width="120" src="https://placeholdit.imgix.net/~text?txtsize=14&amp;txt=producto2&amp;w=120&amp;h=130" alt="Producto 2">
 				<div class="nombre">Producto 2</div>
 				<div class="precio" >1.2</div>
 				<div class="cantidad"><input type="number" value="1" size="4"><a href="#">Añadir</a></div>
 			</article>
 			<article id="articulo3" data-id="3">
-				<img height="130" width="120" src="https://placeholdit.imgix.net/~text?txtsize=14&txt=producto3&w=120&h=130" alt="Producto 3">
+				<img height="130" width="120" src="https://placeholdit.imgix.net/~text?txtsize=14&amp;txt=producto3&amp;w=120&amp;h=130" alt="Producto 3">
 				<div class="nombre">Producto 3</div>
 				<div class="precio" >3.4</div>
 				<div class="cantidad"><input type="number" value="1" size="4"><a href="#">Añadir</a></div>
 			</article>
 			<article id="articulo4" data-id="4">
-				<img height="130" width="120" src="https://placeholdit.imgix.net/~text?txtsize=14&txt=producto4&w=120&h=130" alt="Producto 4">
+				<img height="130" width="120" src="https://placeholdit.imgix.net/~text?txtsize=14&amp;txt=producto4&amp;w=120&amp;h=130" alt="Producto 4">
 				<div class="nombre">Producto 4</div>
 				<div class="precio" >1</div>
 				<div class="cantidad"><input type="number" value="1" size="4"><a href="#">Añadir</a></div>
 			</article>
 			<article id="articulo5" data-id="5">
-				<img height="130" width="120" src="https://placeholdit.imgix.net/~text?txtsize=14&txt=producto5&w=120&h=130" alt="Producto 5">
+				<img height="130" width="120" src="https://placeholdit.imgix.net/~text?txtsize=14&amp;txt=producto5&amp;w=120&amp;h=130" alt="Producto 5">
 				<div class="nombre">Producto 5</div>
 				<div class="precio" >0.89</div>
 				<div class="cantidad"><input type="number" value="1" size="4"><a href="#">Añadir</a></div>
 			</article>
 			<article id="articulo6">
-				<img height="130" width="120" src="https://placeholdit.imgix.net/~text?txtsize=14&txt=producto6&w=120&h=130"  alt="Producto 6">
+				<img height="130" width="120" src="https://placeholdit.imgix.net/~text?txtsize=14&amp;txt=producto6&amp;w=120&amp;h=130"  alt="Producto 6">
 				<div class="nombre">Producto 6</div>
 				<div class="precio" >2.22</div>
 				<div class="cantidad"><input type="number" value="1" size="4"><a href="#">Añadir</a></div>


### PR DESCRIPTION
This PR fixes the header by using a <head> element and specifying manually the character set encoding, instead of relying on browser's autodetection which usually defaults to windows-1252 and displays euro and ñ symbols incorrectly.

Ampersands have been escaped as per HTML specifications.
